### PR TITLE
Add calling pre_system hook

### DIFF
--- a/ci_instance.php
+++ b/ci_instance.php
@@ -68,6 +68,9 @@ $GLOBALS['CFG'] = & load_class('Config', 'core');
 $GLOBALS['UNI'] = & load_class('Utf8', 'core');
 $GLOBALS['SEC'] = & load_class('Security', 'core');
 
+$EXT = & load_class('Hooks', 'core', $GLOBALS['CFG']);
+$EXT->call_hook('pre_system');
+
 load_class('Loader', 'core');
 load_class('Router', 'core');
 load_class('Input', 'core');


### PR DESCRIPTION
Hi. Thanks for the great library!

This PR attempts to add calling `pre_system` hook in `ci_instance.php`

In CodeIgniter3, the `pre_system` hook is called before  initializing Controller, but the hook is not called  in this tool.

https://github.com/bcit-ci/CodeIgniter/blob/63d037565dd782795021dcbd3b1ca6f8c8a509e4/system/core/CodeIgniter.php#L166-L179

Calling `pre_system` hook has the advantage that we can use libraries such as [phpdotenv](https://github.com/vlucas/phpdotenv) to write config files as follows.

```php
# application/config/database.php

$db['default'] = array(
    'dsn'    => '',
    'hostname' => $_ENV["DB_HOST"],
    'username' => $_ENV["DB_USER"],
    'password' => $_ENV["DB_PASS"],
    'database' => $_ENV["DB_NAME"],
```

Thanks.